### PR TITLE
minor updates, primarily to the upgrade process notes, for Django 1.9 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - sudo su - postgres -c "psql roundware -c 'create extension postgis'"
   - pip install -r requirements/dev.txt
   - pip install files/django-admin-bootstrapped-1.9-compatible-master.zip
-# Experiment
   - sudo apt-get install --reinstall python-setuptools
 before_script:
 # Setup Roundware log file.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,52 +19,52 @@ Done!
 The following instructions describe modifications to the standard upgrade process required due to
 specific changes. Items are listed in reverse chronological order.
 
-### 4/28/16 - Upgrade Django from 1.7 to 1.9
+### 6/13/16 - Upgrade Django from 1.7 to 1.9
+Related Github issue: https://github.com/roundware/roundware-server/pull/283
 
 The time has come to upgrade Django and other required apps to their newest versions. If you are
 installing Roundware from scratch, there is no need to take extra steps. However, if your
 installation is based on a commit prior to the Django 1.9 migration, some manual setup is needed.
 
-As part of the upgrade process, [django-guardian](http://django-guardian.readthedocs.io/en/stable/)
+#### Detailed Steps (for production machines, not vagrant)
+
+1. Pull the relevant post-upgrade `roundware-server` commit (or newer)
+2. Initial deploy: `sudo ./deploy.sh` (this will error on `django-guardian` but don't worry,
+   we're about to fix that)
+3. Run migrations
+
+ ```
+ sudo su - roundware -c "/var/www/roundware/source/roundware/manage.py migrate guardian --fake-initial"
+ sudo su - roundware -c "/var/www/roundware/source/roundware/manage.py migrate"
+ ```
+4. Replace apache config (note this will over-write any customizations you may have made)
+
+ ```
+ sudo rm -f /etc/apache2/sites-available/roundware.conf
+ sudo su -
+ sed s/USERNAME/roundware/g /var/www/roundware/source/files/etc-apache2-sites-available-roundware > /etc/apache2/sites-available/roundware.conf
+ ```
+5. `exit` and `sudo ./deploy.sh`
+
+#### Notes / Troubleshooting
+
+* As part of the upgrade process, [django-guardian](http://django-guardian.readthedocs.io/en/stable/)
 must be updated from 1.2.4 to 1.4.4. While the old versions of guardian used `syncdb` to populate
 the database, newer versions use migrations. The database structures are identical; however, these
 migrations do not check if the tables and relationships are already in place. Therefore, you must
 suppress guardian's initial migration.
-
-1. Make sure that you are in `su - roundware` or `su - vagrant` as appropriate
-2. Pull the relevant post-upgrade roundware-server commit (or newer)
-3. Run `pip install -r ~/roundware-server/requirements/dev.txt`
-   This will download the new requirements, both `common` and `dev`
-   Alternatively, you can `./scripts/runserver.sh` and then `Ctrl+C`
-   It should warn you about unapplied migrations
-4. Navigate to the `roundware` folder in your terminal
-5. Run `python manage.py migrate guardian --fake-initial`
-6. Run `python manage.py migrate` for the other migrations
-
-Note that you might have to also manually uninstall `django-chartit`. `django-chartit2` is meant
+* You might have to manually uninstall `django-chartit`. `django-chartit2` is meant
 to be a drop-in replacement, but if `django-chartit` is still installed, it will not work. Ensure
 that the `roundware` user can access all new `site-packages`.
-
-You might also need to uninstall `django-admin-bootstrapped` manually. Symptomatically, if the
-Django admin panel has no theme, it's likely that an old version of `d-a-b` was installed globally
-(`/usr/local/lib`) and is now interfering with the new `d-a-b` in the `virtualenv`. Old versions
+* You might also need to uninstall `django-admin-bootstrapped` manually. Symptomatically, if the
+Django admin panel has no theme, it's likely that an old version of `django-admin-bootstrapped` was installed globally
+(`/usr/local/lib`) and is now interfering with the new `django-admin-bootstrapped` in the `virtualenv`. Old versions
 required `django_admin_bootstrapped.bootstrap3` to be in `INSTALLED_APPS` to render the theme.
 Otherwise, it would fail silently, and no theme would be rendered. Try running `pip freeze`;
-if `d-a-b` is `v2.0.4`, run `pip uninstall django-admin-bootstrapped`.
-
-Next, you must run the following commands:
-
- ```
- rm -f /etc/apache2/sites-available/roundware.conf
- sed s/USERNAME/roundware/g /var/www/roundware/source/files/etc-apache2-sites-available-roundware > /etc/apache2/sites-available/roundware.conf
- # If you are using vagrant, replace roundware with vagrant after USERNAME
- ```
-
-Roundware's `wsgi.py` was moved in this commit, and the Apache conf file must be updated. If you
+if `django-admin-bootstrapped` is `v2.0.4`, run `pip uninstall django-admin-bootstrapped`.
+* Roundware's `wsgi.py` was moved in this commit, and the Apache conf file must be updated. If you
 get 404 errors after upgrading, chances are you skipped this step.
-
-Lastly, ensure that you are not in a virtual environment, and run `./deploy.sh`
-Check the log to ensure that all of the required apps are located in `/var/www/roundware/lib/`
+* Check the log to ensure that all of the required apps are located in `/var/www/roundware/lib/`.
 It isn't necessary, but it might save you some headache with permissions.
 
 ### 3/7/16 - Convert from MySQL to Postgresql for GIS speaker upgrades

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ export PYTHONPATH=$CODE_PATH
 # Install upgrade pip
 pip install -U pip
 
-# Install RoundWare requirements
+# Install Roundware requirements
 pip install -r $CODE_PATH/requirements.txt --upgrade
 
 # Loaded in roundware/settings/common.py

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -42,4 +42,4 @@ fiona
 # geographic extensions for djangorestframework-gis
 djangorestframework-gis==0.10.1
 # leaflet map utilities for django admin
-django-leaflet
+django-leaflet==0.18.0


### PR DESCRIPTION
After extensive testing on production VMs, I have fixed, verified and streamlined the upgrade process. I have only included steps for production upgrades as vagrant upgrades are essentially unnecessary as developers can just spin up a new fresh VM anytime.
